### PR TITLE
Expose type information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed `Typed.typeName` specifiers for `Maybe`, `Enum` and `Discriminator`
+
+### Changed
+
+- Moved logic for `Maybe`, `Enum`, and `Discriminator` into separate classes which expose some typing information
+
 ### Removed
 
 - jsdoc, we are now only using jsdoc-to-markdown

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,4 @@
-const { Record } = require('typed-immutable');
+const { Record, Typed } = require('typed-immutable');
 const { Maybe, Enum, Discriminator, extend } = require('../src');
 
 describe('Maybe', () => {
@@ -12,6 +12,18 @@ describe('Maybe', () => {
     expect(() => {
       Maybe(String, 0);
     }).to.throw(/is not nully nor of String type/);
+  });
+
+  it('should set the Typed.type property', () => {
+    expect(Maybe(String)).to.have.property(Typed.type, Typed.String.prototype);
+  });
+
+  it('should have an appropriate Typed.typeValue with no default value', () => {
+    expect(Maybe(String)[Typed.typeName]()).to.equal('Maybe(String)');
+  });
+
+  it('should have an appropriate Typed.typeValue with a default value', () => {
+    expect(Maybe(String, 'abc')[Typed.typeName]()).to.equal('Maybe(String, "abc")');
   });
 
   it('should allow an undefined value', () => {
@@ -249,6 +261,14 @@ describe('Enum', () => {
     record = record.delete('value');
     expect(record.value).to.equal('bar');
   });
+
+  it('should have an appropriate Typed.typeValue with no default value', () => {
+    expect(Enum(['foo', 'bar'])[Typed.typeName]()).to.equal('Enum(["foo","bar"])');
+  });
+
+  it('should have an appropriate Typed.typeValue with a default value', () => {
+    expect(Enum(['foo', 'bar'], 'foo')[Typed.typeName]()).to.equal('Enum(["foo","bar"], "foo")');
+  });
 });
 
 describe('Discriminator', () => {
@@ -259,15 +279,15 @@ describe('Discriminator', () => {
   beforeEach(() => {
     A = Record({
       type: String,
-    });
+    }, 'A');
 
     B = Record({
       type: String,
-    });
+    }, 'B');
 
     C = Record({
       type: String,
-    });
+    }, 'C');
   });
 
   it('should throw if the property is not specified', () => {
@@ -602,6 +622,20 @@ describe('Discriminator', () => {
       },
     });
     expect(record.value).to.be.an.instanceOf(D);
+  });
+
+  it('should have an appropriate Typed.typeValue with no default value', () => {
+    expect(Discriminator('type', {
+      a: A,
+      b: B,
+    })[Typed.typeName]()).to.equal('Discriminator("type", {"a":"A","b":"B"})');
+  });
+
+  it('should have an appropriate Typed.typeValue with a default value', () => {
+    expect(Discriminator('type', {
+      a: A,
+      b: B,
+    }, C)[Typed.typeName]()).to.equal('Discriminator("type", {"a":"A","b":"B"}, "C")');
   });
 });
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

This PR moves most of the logic into classes which are derived from typed-immutable's `Type` and exposes these classes as a `Type` property on the corresponding functions.  In this way, it's possible to detect whether a property type is derived from `Maybe`, `Enum`, or `Discriminator`, and it's also possible to get more detailed information out of those types.  This also fixes up the typeName information for these types to make them more accurate.

Resolves #6 

**Checklist**

- [X] Unit tests added
- [x] Documentation is up-to-date
- [x] Changelog is updated
- [x] Ran `npm run build:all`